### PR TITLE
FIX pmp into past was wrong when pmp init is null (and it was wrong too)

### DIFF
--- a/class/inventory.class.php
+++ b/class/inventory.class.php
@@ -139,14 +139,19 @@ class TInventory extends TObjetStd
     }
     
     function add_product(&$PDOdb, $fk_product, $fk_entrepot='', $addWithCurrentDetails = false) {
-        
+  	global $langs;
+	if(empty($fk_product)) {
+		setEventMessages($langs->trans('ErrorNoSelectedProductToAdd'), 'errors');
+		return false;
+	}
+      
         $k = $this->addChild($PDOdb, 'TInventorydet');
         $det =  &$this->TInventorydet[$k];
         
         $det->fk_inventory = $this->getId();
         $det->fk_product = $fk_product;
-		$det->fk_warehouse = empty($fk_entrepot) ? $this->fk_warehouse : $fk_entrepot;
-        
+	$det->fk_warehouse = empty($fk_entrepot) ? $this->fk_warehouse : $fk_entrepot;
+//        var_dump($det);exit;
         $det->load_product();
                 
         if($addWithCurrentDetails) {
@@ -323,7 +328,6 @@ class TInventorydet extends TObjetStd
 		
         $this->qty_stock = $stock;
         $this->pmp = $pmp;
-        
         $last_pa = 0;
         $sql = "SELECT price FROM ".MAIN_DB_PREFIX."stock_mouvement 
                 WHERE fk_entrepot=".$fk_warehouse." 
@@ -347,19 +351,19 @@ class TInventorydet extends TObjetStd
 	function getPmpStockFromDate(&$PDOdb, $date, $fk_warehouse){
 		
 		$res = $this->product->load_stock();
-		
+//		var_dump($res, $this->product);
 		if($res>0) {
 			$stock = isset($this->product->stock_warehouse[$fk_warehouse]->real) ? $this->product->stock_warehouse[$fk_warehouse]->real : 0;
-			
-			if((float)DOL_VERSION<4.0) {
-				$pmp = isset($this->product->stock_warehouse[$fk_warehouse]->pmp) ? $this->product->stock_warehouse[$fk_warehouse]->pmp : 0; 
+
+			if(isset($this->product->stock_warehouse[$fk_warehouse]->pmp))$this->product->stock_warehouse[$fk_warehouse]->pmp = (float)$this->product->stock_warehouse[$fk_warehouse]->pmp;
+
+			if(empty($this->product->stock_warehouse[$fk_warehouse]->pmp)) $pmp = (float)$this->product->pmp;
+			else {
+				$pmp = $this->product->stock_warehouse[$fk_warehouse]->pmp;
 			}
-			else{
-				$pmp = $this->product->pmp;
-			}
-			
+
 		}
-		
+
 		//On récupère tous les mouvements de stocks du produit entre aujourd'hui et la date de l'inventaire
 		$sql = "SELECT value, price
 				FROM ".MAIN_DB_PREFIX."stock_mouvement
@@ -376,25 +380,20 @@ class TInventorydet extends TObjetStd
 		//Pour chacun des mouvements on recalcule le PMP et le stock physique
 		foreach($TMouvementStock as $mouvement){
 			
-			//150
-			//if($this->product->id==394) echo 'laststock = '.$stock.'<br>';
-			
-			//9.33
-			//if($this->product->id==394) echo 'lastpmp = '.$pmp.'<br>';
-			$price = ($mouvement->price>0 && $mouvement->value>0) ? $mouvement->price : $lastpmp;  
+			$price = ($mouvement->price>0 && $mouvement->value>0) ? $mouvement->price : $lastpmp;  // prix du mouvement si positif
 				
-			$stock_value = $laststock * $lastpmp;
+			$stock_value = $laststock * $lastpmp; // valeur du stock
 			
-			$laststock -= $mouvement->value;
+			$laststock -= $mouvement->value; // recalcul du stock en fonction du mouvement
 			
-			$last_stock_value = $stock_value - ($mouvement->value * $price);	
-			
-			$lastpmp = ($laststock != 0) ? $last_stock_value / $laststock : $lastpmp;
-			 
-			
+			$last_stock_value = $stock_value - ($mouvement->value * $price); // valorisation du stock en fonction du mouvement
+			if($last_stock_value < 0) $last_stock_value = 0;
 
+			//if($last_stock_value<0 || $laststock<0) null; 
+			$lastpmp = ($laststock != 0) ? $last_stock_value / $laststock : $lastpmp; // S'il y a un stock, alors son PMP est sa valeur totale / nombre de pièce
+			 
 		}
-		
+
 		return array($lastpmp,$laststock);
 	}
     


### PR DESCRIPTION
- Le PMP dans le warehouse est null si pas de stock, mais pas de bol ce n'est pas le PMP du produit
- Si à un moment du calcul la valeur du stock et à zéro, c'est faux, il faut la ramener à nulle